### PR TITLE
Allocate new GUIDs for Compiler COM interfaces to avoid conflict with …

### DIFF
--- a/Compiler/Compiler.idl
+++ b/Compiler/Compiler.idl
@@ -8,9 +8,9 @@ import "oaidl.idl";
 import "ocidl.idl";
 
 [
-	uuid(CF88CAFD-2993-11D3-8366-6E485B000000),
-	version(6.0),
-	helpstring("Dolphin Smalltalk Compiler 6.0")
+	uuid(446CBAE8-D3AD-4D40-9A50-20D725195AF7),
+	version(7.0),
+	helpstring("Dolphin Smalltalk Compiler 7.0")
 ]
 library CompilerLib
 {
@@ -152,11 +152,14 @@ library CompilerLib
 	};
 
 	[
-		// uuid(CF88CAFC-2993-11D3-8366-6E485B000000) 3.05
-		//uuid(C47CCC7F-A6B6-401E-8853-F1EC1D20114D) 4.x
+		//uuid(CF88CAFC-2993-11D3-8366-6E485B000000)	// 3.05
+		//uuid(C47CCC7F-A6B6-401E-8853-F1EC1D20114D)	// 4.x
 		//uuid(77A96CF7-0709-4EE5-ABCD-EF11735CEA0D)	// 5.0
 		//uuid(52DE08AC-F761-4D50-9FC5-964156F8A0D5)	// 5.04
-		uuid(B1401906-004A-4D84-8A8D-7D7D5F7FEC92)	// 6.0
+		//uuid(B1401906-004A-4D84-8A8D-7D7D5F7FEC92)	// 6.0
+		uuid(F27D15BD-B8EB-488C-9932-C7FA0C598640)		// 7.0
+
+		
 	]
 	coclass DolphinCompiler
 	{

--- a/Compiler/compiler.h
+++ b/Compiler/compiler.h
@@ -52,7 +52,7 @@ class ATL_NO_VTABLE Compiler : public Lexer,
 {
 public:
 
-DECLARE_REGISTRY(Compiler, "Dolphin.Compiler.6", "Dolphin.Compiler", IDR_COMPILER, THREADFLAGS_APARTMENT)
+DECLARE_REGISTRY(Compiler, "Dolphin.Compiler.7", "Dolphin.Compiler", IDR_COMPILER, THREADFLAGS_APARTMENT)
 
 DECLARE_NOT_AGGREGATABLE(Compiler)
 


### PR DESCRIPTION
…previous Dolphin installations. Closes #2.